### PR TITLE
Added block sorted connection API

### DIFF
--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __all__ = [
     "PlacementSet",
     "ConnectivitySet",

--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.2.5"
+__version__ = "0.3.0"
 
 
 def on_main(prep=None, ret=None):

--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -6,7 +6,6 @@ from .placement_set import PlacementSet
 from .connectivity_set import ConnectivitySet
 from .file_store import FileStore
 from .morphology_repository import MorphologyRepository
-from contextlib import contextmanager
 from datetime import datetime
 import h5py
 import os
@@ -14,6 +13,14 @@ import shutil
 import shortuuid
 
 __version__ = "0.3.1"
+__all__ = [
+    "PlacementSet",
+    "ConnectivitySet",
+    "FileStore",
+    "MorphologyRepository",
+    "HDF5Engine",
+    "StorageNode",
+]
 
 
 def on_main(prep=None, ret=None):

--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __all__ = [
     "PlacementSet",
     "ConnectivitySet",

--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -13,19 +13,19 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 def on_main(prep=None, ret=None):
     def decorator(f):
         def wrapper(self, *args, **kwargs):
             r = None
-            self.comm.Barrier()
-            if self.comm.Get_rank() == 0:
+            self.comm.barrier()
+            if self.comm.get_rank() == 0:
                 r = f(self, *args, **kwargs)
             elif prep:
                 prep(self, *args, **kwargs)
-            self.comm.Barrier()
+            self.comm.barrier()
             if not ret:
                 return self.comm.bcast(r, root=0)
             else:
@@ -41,12 +41,12 @@ def on_main_until(until, prep=None, ret=None):
         def wrapper(self, *args, **kwargs):
             global _procpass
             r = None
-            self.comm.Barrier()
-            if self.comm.Get_rank() == 0:
+            self.comm.barrier()
+            if self.comm.get_rank() == 0:
                 r = f(self, *args, **kwargs)
             elif prep:
                 prep(self, *args, **kwargs)
-            self.comm.Barrier()
+            self.comm.barrier()
             while not until(self, *args, **kwargs):
                 pass
             if not ret:

--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 
 def on_main(prep=None, ret=None):

--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __all__ = [
     "PlacementSet",
     "ConnectivitySet",

--- a/bsb_hdf5/chunks.py
+++ b/bsb_hdf5/chunks.py
@@ -9,7 +9,6 @@ ConnectivitySet) to organize :class:`.ChunkedProperty` and :class:`.ChunkedColle
 objects within them.
 """
 
-from .resource import Resource
 from bsb.storage._chunks import Chunk
 import numpy as np
 import contextlib

--- a/bsb_hdf5/chunks.py
+++ b/bsb_hdf5/chunks.py
@@ -85,15 +85,16 @@ class ChunkLoader:
         """
         Add a chunk to read data from when loading properties/collections.
         """
-        self._chunks.add(chunk)
+        self._chunks.add(chunk if isinstance(chunk, Chunk) else Chunk(chunk, None))
 
     def unload_chunk(self, chunk):
         """
         Remove a chunk to read data from when loading properties/collections.
         """
-        self._chunks.discard(chunk)
+        self._chunks.discard(chunk if isinstance(chunk, Chunk) else Chunk(chunk, None))
 
     def set_chunks(self, chunks):
+        chunks = _to_chunklist(chunks)
         self._chunks = set(chunks)
 
     def clear_chunks(self):
@@ -138,6 +139,10 @@ class ChunkLoader:
 
     def _get_chunk_size(self, handle):
         return handle.attrs["chunk_size"]
+
+
+def _to_chunklist(chunks):
+    return [c if isinstance(c, Chunk) else Chunk(c, None) for c in chunks]
 
 
 class ChunkedProperty:

--- a/bsb_hdf5/chunks.py
+++ b/bsb_hdf5/chunks.py
@@ -132,10 +132,11 @@ class ChunkLoader:
                 prop.clear(chunk)
 
     def _set_chunk_size(self, handle, size):
-        fsize = handle.attrs.get("chunk_size", size)
-        if not np.any(np.isnan(fsize)) and not np.allclose(fsize, size):
+        fsize = handle.attrs.get("chunk_size", np.full(3, np.nan))
+        if np.all(np.isnan(fsize)):
+            handle.attrs["chunk_size"] = size
+        elif not np.all(np.isnan(size)) and not np.allclose(fsize, size):
             raise Exception(f"Chunk size mismatch. File: {fsize}. Given: {size}")
-        handle.attrs["chunk_size"] = size
 
     def _get_chunk_size(self, handle):
         return handle.attrs["chunk_size"]

--- a/bsb_hdf5/chunks.py
+++ b/bsb_hdf5/chunks.py
@@ -132,7 +132,7 @@ class ChunkLoader:
 
     def _set_chunk_size(self, handle, size):
         fsize = handle.attrs.get("chunk_size", size)
-        if not np.allclose(fsize, size):
+        if not np.any(np.isnan(fsize)) and not np.allclose(fsize, size):
             raise Exception(f"Chunk size mismatch. File: {fsize}. Given: {size}")
         handle.attrs["chunk_size"] = size
 

--- a/bsb_hdf5/connectivity_set.py
+++ b/bsb_hdf5/connectivity_set.py
@@ -129,6 +129,12 @@ class ConnectivitySet(Resource, IConnectivitySet):
         raise NotImplementedError("Will do once I have some sample data :)")
 
     def connect(self, pre_set, post_set, src_locs, dest_locs):
+        src_locs = np.array(src_locs, copy=False)
+        dest_locs = np.array(dest_locs, copy=False)
+        if not len(src_locs):
+            return
+        if len(src_locs) != len(dest_locs):
+            raise ValueError("Location matrices must be of same length.")
         with self._engine._write():
             with self._engine._handle("a") as handle:
                 for data in self._demux(pre_set, post_set, src_locs, dest_locs):

--- a/bsb_hdf5/connectivity_set.py
+++ b/bsb_hdf5/connectivity_set.py
@@ -123,7 +123,7 @@ class ConnectivitySet(Resource, IConnectivitySet):
             print(sum(src_idx), "connections found for", ln, "cells.")
             src_block = src_locs[src_idx]
             dst_block = dst_locs[src_idx]
-            block_idx = np.lexsort((src_block[:, 0], dst_block[:, 0]))
+            block_idx = np.lexsort((dst_block[:, 0], src_block[:, 0]))
             yield src, dst, src_block[block_idx], dst_block[block_idx]
             src_locs = src_locs[~src_idx]
             dst_locs = dst_locs[~src_idx]
@@ -193,7 +193,7 @@ class ConnectivitySet(Resource, IConnectivitySet):
         self._insert("out", src_chunk, dest_chunk, lloc, gloc, handle)
 
     def _insert(self, tag, local, global_, lloc, gloc, handle):
-        grp = h.require_group(f"{self._path}/{tag}/{local.id}")
+        grp = handle.require_group(f"{self._path}/{tag}/{local.id}")
         src_id = str(global_.id)
         unpack_me = [None, None]
         # require_dataset doesn't work for resizable datasets, see

--- a/bsb_hdf5/connectivity_set.py
+++ b/bsb_hdf5/connectivity_set.py
@@ -34,6 +34,9 @@ class ConnectivitySet(Resource, IConnectivitySet):
 
     @classmethod
     def get_tags(cls, engine):
+        """
+        Returns all the connectivity tags in the network.
+        """
         with engine._read():
             with engine._handle("r") as h:
                 return list(h[_root].keys())
@@ -61,6 +64,19 @@ class ConnectivitySet(Resource, IConnectivitySet):
 
     @staticmethod
     def exists(engine, tag, handle=None):
+        """
+        Checks whether a :class:`~.connectivity_set.ConnectivitySet` with the given tag
+        exists.
+
+        :param engine: Engine to use for the lookup.
+        :type engine: :class:`.HDF5Engine`
+        :param tag: Tag of the set to look for.
+        :type tag: str
+        :param handle: An open handle to use instead of opening one.
+        :type handle: :class:`h5py.File`
+        :returns: Whether the tag exists.
+        :rtype: bool
+        """
         check = lambda h: _root + tag in h
         if handle is not None:
             return check(handle)
@@ -71,6 +87,21 @@ class ConnectivitySet(Resource, IConnectivitySet):
 
     @classmethod
     def require(cls, engine, pre_type, post_type, tag=None):
+        """
+        Get or create a :class:`~.connectivity_set.ConnectivitySet`.
+
+        :param engine: Engine to fetch/write the data.
+        :type engine: :class:`.HDF5Engine`
+        :param pre_type: Presynaptic cell type.
+        :type pre_type: :class:`~bsb.cell_types.CellType`
+        :param post_type: Postsynaptic cell type.
+        :type post_type: :class:`~bsb.cell_types.CellType`
+        :param tag: Tag to store the set under. Defaults to
+          ``{pre_type.name}_to_{post_type.name}``.
+        :type tag: str
+        :returns: Existing or new connectivity set.
+        :rtype: :class:`~.connectivity_set.ConnectivitySet`
+        """
         if tag is None:
             tag = f"{pre_type.name}_to_{post_type.name}"
         path = _root + tag

--- a/bsb_hdf5/connectivity_set.py
+++ b/bsb_hdf5/connectivity_set.py
@@ -305,10 +305,10 @@ class ConnectivitySet(Resource, IConnectivitySet):
         :type direction: str
         :param local_: When omitted, iterates over all local chunks in the set. When
           given, it restricts the iteration to the given value(s).
-        :type local_: Union[Chunk, list[Chunk]]
+        :type local_: Union[~bsb.storage.Chunk, list[~bsb.storage.Chunk]]
         :param global_: When omitted, iterates over all global chunks in the set. When
           given, it restricts the iteration to the given value(s).
-        :type global_: Union[Chunk, list[Chunk]]
+        :type global_: Union[~bsb.storage.Chunk, list[~bsb.storage.Chunk]]
         :returns: An iterator that produces the next unrestricted iteration values, or
           the connection dataset that matches the iteration combination.
         """
@@ -338,7 +338,7 @@ class ConnectivitySet(Resource, IConnectivitySet):
         :returns: Yields the direction, local chunk, global chunk, and data. The data is a
           tuple of the local and global connection locations.
         :rtype: Tuple[str, ~bsb.storage.Chunk, ~bsb.storage.Chunk,
-          Tuple[np.ndarray, np.ndarray]]
+          Tuple[numpy.ndarray, numpy.ndarray]]
         """
         itr = CSIterator(self, direction, local_, global_)
         for dir in itr.get_dir_iter(direction):
@@ -360,7 +360,7 @@ class ConnectivitySet(Resource, IConnectivitySet):
         :param global_: Global chunk
         :type global_: ~bsb.storage.Chunk
         :returns: The local and global connections locations
-        :rtype: Tuple[np.ndarray, np.ndarray]
+        :rtype: Tuple[numpy.ndarray, numpy.ndarray]
         """
         if handle is None:
             with self._engine._read():
@@ -390,7 +390,7 @@ class ConnectivitySet(Resource, IConnectivitySet):
           (1 chunk id per connection) and the global connections locations. To identify a
           cell in the global connections, use the corresponding chunk id from the second
           return value.
-        :rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+        :rtype: Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]
         """
         if handle is None:
             with self._engine._read():

--- a/bsb_hdf5/file_store.py
+++ b/bsb_hdf5/file_store.py
@@ -1,6 +1,5 @@
 from bsb.storage.interfaces import FileStore as IFileStore
 from .resource import Resource
-from bsb.exceptions import *
 from uuid import uuid4
 import json
 import io
@@ -53,6 +52,12 @@ class FileStore(Resource, IFileStore):
         return id
 
     def load_active_config(self):
+        """
+        Load the active configuration stored inside of the storage.
+
+        :returns: The active configuration that is loaded when this storage object is.
+        :rtype: ~bsb.config.Configuration
+        """
         from bsb.config import Configuration
 
         cfg_id = self._active_config_id()
@@ -68,6 +73,13 @@ class FileStore(Resource, IFileStore):
             return cfg
 
     def store_active_config(self, config):
+        """
+        Set the active configuration for this network.
+
+        :param config: The active configuration that will be loaded when this storage
+          object is.
+        :type config: ~bsb.config.Configuration
+        """
         id = self._active_config_id()
         self._engine.comm.barrier()
         if id is not None and self._engine.comm.get_rank() == 0:

--- a/bsb_hdf5/file_store.py
+++ b/bsb_hdf5/file_store.py
@@ -69,12 +69,12 @@ class FileStore(Resource, IFileStore):
 
     def store_active_config(self, config):
         id = self._active_config_id()
-        self._engine.comm.Barrier()
-        if id is not None and self._engine.comm.Get_rank() == 0:
+        self._engine.comm.barrier()
+        if id is not None and self._engine.comm.get_rank() == 0:
             self.remove(id)
         config._meta["active_config"] = True
         active_id = None
-        if self._engine.comm.Get_rank() == 0:
+        if self._engine.comm.get_rank() == 0:
             meta = {k: v for k, v in config._meta.items() if v is not None}
             active_id = self.store(json.dumps(config.__tree__()), meta)
         return self._engine.comm.bcast(active_id, root=0)

--- a/bsb_hdf5/morphology_repository.py
+++ b/bsb_hdf5/morphology_repository.py
@@ -1,5 +1,5 @@
 from bsb.morphologies import Morphology, Branch, _Labels
-from bsb.exceptions import *
+from bsb.exceptions import MorphologyRepositoryError, MissingMorphologyError
 from bsb.storage.interfaces import (
     MorphologyRepository as IMorphologyRepository,
     StoredMorphology,
@@ -58,7 +58,7 @@ class MorphologyRepository(Resource, IMorphologyRepository):
             with self._engine._handle("r") as repo:
                 try:
                     root = repo[f"{self._path}/{name}/"]
-                except:
+                except Exception:
                     raise MissingMorphologyError(
                         f"`{self._engine.root}` contains no morphology named `{name}`."
                     ) from None
@@ -111,8 +111,9 @@ class MorphologyRepository(Resource, IMorphologyRepository):
                     if overwrite:
                         self.remove(name)
                     else:
+                        root = self._engine.root
                         raise MorphologyRepositoryError(
-                            f"A morphology called '{name}' already exists in `{self._engine.root}`."
+                            f"A morphology called '{name}' already exists in `{root}`."
                         )
                 root = me.create_group(name)
                 # Optimizing a morphology goes through the same steps as what is required
@@ -143,7 +144,7 @@ class MorphologyRepository(Resource, IMorphologyRepository):
                 try:
                     for k, v in morphology.meta.items():
                         root.attrs[f"meta:{k}"] = v if v is not None else np.nan
-                except:
+                except Exception:
                     raise MorphologyRepositoryError(
                         f"Trying to store invalid {type(v)} metadata '{k}' on `{name}`."
                     ) from None

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -1,4 +1,5 @@
 from bsb.exceptions import *
+from bsb.storage import Chunk
 from bsb.storage.interfaces import PlacementSet as IPlacementSet
 from bsb.morphologies import MorphologySet, RotationSet
 from bsb.morphologies.selector import MorphologySelector
@@ -185,6 +186,10 @@ class PlacementSet(
           rotational or morphological data.
         :type count: int
         """
+        if not isinstance(chunk, Chunk):
+            chunk = Chunk(chunk, None)
+        if positions is not None:
+            positions = np.array(positions, copy=False)
         if count is not None:
             if not (positions is None and morphologies is None):
                 raise ValueError(

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -14,15 +14,15 @@ import itertools
 
 
 def _pos_prop(loader):
-    ChunkedProperty(loader, "position", shape=(0, 3), dtype=float)
+    return ChunkedProperty(loader, "position", shape=(0, 3), dtype=float)
 
 
 def _rot_prop(loader):
-    ChunkedProperty(loader, "rotation", shape=(0, 3), dtype=float)
+    return ChunkedProperty(loader, "rotation", shape=(0, 3), dtype=float)
 
 
 def _morpho_prop(loader):
-    ChunkedProperty(loader, "morphology", shape=(0,), dtype=int)
+    return ChunkedProperty(loader, "morphology", shape=(0,), dtype=int)
 
 
 _root = "/placement/"

--- a/bsb_hdf5/resource.py
+++ b/bsb_hdf5/resource.py
@@ -46,7 +46,7 @@ class Resource:
     def get_attribute(self, name):
         attrs = self.attributes
         if name not in attrs:
-            raise AttributeMissingError(
+            raise AttributeError(
                 "Attribute '{}' not found in '{}'".format(name, self._path)
             )
         return attrs[name]
@@ -90,14 +90,14 @@ class Resource:
             with self._engine._handle("a") as f:
                 try:
                     d = f[self._path]
-                except:
+                except Exception:
                     shape = list(new_data.shape)
                     shape[0] = None
                     d = f.create_dataset(
                         self._path, data=new_data, dtype=dtype, maxshape=tuple(shape)
                     )
                 else:
-                    l = d.shape[0]
-                    l += len(new_data)
-                    d.resize(l, axis=0)
+                    len_ = d.shape[0]
+                    len_ += len(new_data)
+                    d.resize(len_, axis=0)
                     d[-len(new_data) :] = new_data

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "bsb": ("https://bsb.readthedocs.io/en/latest/", None),
     "errr": ("https://errr.readthedocs.io/en/latest/", None),
+    "h5py": ("https://docs.h5py.org/en/latest/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 h5py==3.6.0
-bsb[mpi]==4.0.0a29
+bsb[mpi]==4.0.0a31
 coverage==5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-h5py==3.6.0
-bsb[mpi]==4.0.0a31
+bsb[mpi]==4.0.0a33
 coverage==5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bsb[mpi]==4.0.0a33
+bsb[mpi]==4.0.0a35
 coverage==5.4

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb~=4.0.0a30",
+    "bsb~=4.0.0a31",
     "shortuuid",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb~=4.0.0a33",
+    "bsb~=4.0.0a35",
     "shortuuid",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setuptools.setup(
         "Documentation": "https://bsb-hdf5.readthedocs.io/",
         "Source Code": "https://github.com/dbbs-lab/bsb-hdf5/",
     },
-    extras_require={},
+    extras_require={"dev": ["sphinx", "sphinxemoji", "furo", "sphinx_design"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb~=4.0.0a31",
+    "bsb~=4.0.0a32",
     "shortuuid",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb~=4.0.0a29",
+    "bsb~=4.0.0a30",
     "shortuuid",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,22 @@
-import setuptools, sys, os
+import setuptools
+import os
 
-with open(os.path.join(os.path.dirname(__file__), "bsb_hdf5", "__init__.py"), "r") as f:
+_findver = "__version__ = "
+_rootpath = os.path.join(os.path.dirname(__file__), "bsb_hdf5", "__init__.py")
+with open(_rootpath, "r") as f:
     for line in f:
         if "__version__ = " in line:
-            exec(line.strip())
+            f = line.find(_findver)
+            __version__ = eval(line[line.find(_findver) + len(_findver) :])
             break
+    else:
+        raise Exception(f"No `__version__` found in '{_rootpath}'.")
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb~=4.0.0a32",
+    "bsb~=4.0.0a33",
     "shortuuid",
 ]
 

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -2,6 +2,7 @@ from bsb.unittest.engines import (
     TestStorage as _TestStorage,
     TestPlacementSet as _TestPlacementSet,
     TestMorphologyRepository as _TestMorphologyRepository,
+    TestConnectivitySet as _TestConnectivitySet,
 )
 import unittest
 
@@ -17,4 +18,8 @@ class TestPlacementSet(_TestPlacementSet, unittest.TestCase, engine_name="hdf5")
 class TestMorphologyRepository(
     _TestMorphologyRepository, unittest.TestCase, engine_name="hdf5"
 ):
+    pass
+
+
+class TestConnectivitySet(_TestConnectivitySet, unittest.TestCase, engine_name="hdf5"):
     pass

--- a/test/test_mr.py
+++ b/test/test_mr.py
@@ -11,7 +11,7 @@ class TestHandcrafted(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        if MPI.Get_rank() == 0:
+        if MPI.get_rank() == 0:
             with h5py.File("test.h5", "w") as f:
                 g = f.create_group("morphologies")
                 g = g.create_group("M")
@@ -57,18 +57,18 @@ class TestHandcrafted(unittest.TestCase):
                 ds.attrs["labels"] = json.dumps({1: []})
                 ds.attrs["properties"] = []
                 g.create_dataset("graph", data=[[i + 1, -1] for i in range(4)] + [[5, 0]])
-        MPI.Barrier()
+        MPI.barrier()
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        if MPI.Get_rank() == 0:
+        if MPI.get_rank() == 0:
             os.remove("test.h5")
             os.remove("test2.h5")
             os.remove("test3.h5")
             os.remove("test4.h5")
             os.remove("test5.h5")
-        MPI.Barrier()
+        MPI.barrier()
 
     def test_empty_repository(self):
         pass

--- a/test/test_mr.py
+++ b/test/test_mr.py
@@ -65,6 +65,7 @@ class TestHandcrafted(unittest.TestCase):
         if MPI.Get_rank() == 0:
             os.remove("test.h5")
             os.remove("test2.h5")
+            os.remove("test3.h5")
             os.remove("test4.h5")
             os.remove("test5.h5")
         MPI.Barrier()

--- a/test/test_setup/__init__.py
+++ b/test/test_setup/__init__.py
@@ -4,25 +4,26 @@ import numpy as np
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
-def get_config(file):
+def get_data_path(*paths):
     return os.path.abspath(
         os.path.join(
             os.path.dirname(__file__),
             "..",
             "data",
-            "configs",
-            file + (".json" if not file.endswith(".json") else ""),
+            *paths,
         )
     )
 
 
-def get_morphology(file):
-    return os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "data",
-            "morphologies",
-            file,
-        )
+def get_config_path(file):
+    return get_data_path(
+        "configs",
+        file + (".json" if not file.endswith(".json") else ""),
+    )
+
+
+def get_morphology_path(file):
+    return get_data_path(
+        "morphologies",
+        file,
     )


### PR DESCRIPTION
Connections are now added both as `inc` (incoming) and `out` (outgoing) connections. This duplication allows for nodes to query only the chunks they own, and find all the information they need to hand over the data to the simulators.

* In `inc` blocks, the local chunk is the target of the connections, and the global chunks are sources of connections arriving from anywhere in the network.
* In `out` blocks, the local chunk is the source of the connections, and the global chunks are targets of connections to anywhere in the network.

Added a write API:

* `connect` takes 2 placement sets, and a source and dest matrix. It demultiplexes and cross combines all the chunks in the 2 placement sets, and then calls `chunk_connect` on the chunk combination and corresponding demultiplexed data.

Added a readout API:

* `nested_iter_connections`: can take 0 to 3 arguments, to pin `dir`, `lchunk` or `gchunk` to some value, and needs 3 to 0 nested for loops to work. This approach allows the user to run code before or after a scan of a dimension has completed.
* `flat_iter_connections`: yields the same data as the nested iter, but flattens it to 1 row of `dir`, `lchunk`, `gchunks` and `data`.