### PR TITLE
Fixed empty CS block read and added OOB check for write

### DIFF
--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import shortuuid
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__ = [
     "PlacementSet",
     "ConnectivitySet",

--- a/bsb_hdf5/connectivity_set.py
+++ b/bsb_hdf5/connectivity_set.py
@@ -341,8 +341,13 @@ class ConnectivitySet(Resource, IConnectivitySet):
         :returns: The local and global connections locations
         :rtype: Tuple[numpy.ndarray, numpy.ndarray]
         """
-        local_grp = handle[self._path][f"{direction}/{local_.id}"]
-        start, end = self._get_insert_pointers(local_grp, global_)
+        try:
+            local_grp = handle[self._path][f"{direction}/{local_.id}"]
+            start, end = self._get_insert_pointers(local_grp, global_)
+        except KeyError:
+            # If a local or global chunk isn't found, return empty data.
+            return (np.empty((0, 3), dtype=int), np.empty((0, 3), dtype=int))
+
         idx = slice(start, end)
         return (local_grp["local_locs"][idx], local_grp["global_locs"][idx])
 

--- a/bsb_hdf5/connectivity_set.py
+++ b/bsb_hdf5/connectivity_set.py
@@ -7,6 +7,10 @@ import numpy as np
 _root = "/connectivity/"
 
 
+class LocationOutOfBoundsError(Exception):
+    pass
+
+
 class ConnectivitySet(Resource, IConnectivitySet):
     """
     Fetches placement data from storage.
@@ -155,6 +159,7 @@ class ConnectivitySet(Resource, IConnectivitySet):
         for src in iter(src_chunks):
             with pre.chunk_context(src):
                 lns.append(len(pre))
+        dmax = 0
         # Iterate over each source chunk
         for dst in post.get_loaded_chunks():
             # Count the number of cells
@@ -167,14 +172,31 @@ class ConnectivitySet(Resource, IConnectivitySet):
                 block_idx = np.lexsort((src_block[:, 0], dst_block[:, 0]))
                 yield src, dst, src_block[block_idx], dst_block[block_idx]
             else:
-                for src, dln in zip(iter(src_chunks), lns):
+                for src, sln in zip(iter(src_chunks), lns):
                     block_idx = (src_block[:, 0] >= 0) & (src_block[:, 0] < dln)
                     yield src, dst, src_block[block_idx], dst_block[block_idx]
-                    src_block[:, 0] -= dln
+                    src_block[:, 0] -= sln
             dst_locs = dst_locs[~dst_idx]
             src_locs = src_locs[~dst_idx]
             # We sifted `ln` cells out of the dataset, so reduce the ids.
             dst_locs[:, 0] -= ln
+            dmax += ln
+        if len(dst_locs) > 0:
+            smax = sum(lns) - 1
+            dmax -= 1
+            src_msg = ""
+            if (m := np.max(src_locs)) > smax:
+                src_msg = f"Source maximum is {smax}, but up to {m} given."
+            dst_msg = ""
+            if (m := np.max(src_locs)) > smax:
+                if src_msg:
+                    dst_msg = "\n"
+                dst_msg += f"Destination maximum is {dmax}, but up to {m} given."
+            raise LocationOutOfBoundsError(
+                f"Received {len(dst_locs)} out of bounds locations:"
+                f"\n- Source locations:\n{src_locs}"
+                f"\n- Destinations:\n{dst_locs}\n" + src_msg + dst_msg
+            )
 
     def _store_pointers(self, group, chunk, n, total):
         chunks = [Chunk(t, (0, 0, 0)) for t in group.attrs.get("chunk_list", [])]
@@ -377,6 +399,13 @@ class ConnectivitySet(Resource, IConnectivitySet):
 
     @handles_handles("r")
     def load_connections(self, direction="out", handle=HANDLED):
+        """
+        Load all connections. Careful, may lead to out of memory errors for large
+        connection sets.
+
+        :param direction: Incoming or outgoing perspective.
+        :type direction: str
+        """
         chunks = self.get_local_chunks(direction, handle=handle)
         locals = []
         cids = []

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -325,6 +325,12 @@ class PlacementSet(
         self._labels = labels
 
     def set_morphology_label_filter(self, morphology_labels):
+        """
+        Sets the labels by which any morphology loaded from this set will be filtered.
+
+        :param morphology_labels: List of labels to filter the morphologies by.
+        :type morphology_labels: List[str]
+        """
         self._morphology_labels = morphology_labels
 
     @handles_handles("r")

--- a/test/test_cs.py
+++ b/test/test_cs.py
@@ -1,0 +1,33 @@
+from bsb.unittest import FixedPosConfigFixture, RandomStorageFixture, NumpyTestCase
+from bsb.core import Scaffold
+import unittest
+
+
+class TestConnectivitySet(
+    FixedPosConfigFixture,
+    RandomStorageFixture,
+    NumpyTestCase,
+    unittest.TestCase,
+    engine_name="hdf5",
+):
+    def setUp(self):
+        super().setUp()
+        self.cfg.connectivity.add(
+            "all_to_all",
+            dict(
+                strategy="bsb.connectivity.AllToAll",
+                presynaptic=dict(cell_types=["test_cell"]),
+                postsynaptic=dict(cell_types=["test_cell"]),
+            ),
+        )
+        self.network = Scaffold(self.cfg, self.storage)
+        self.network.compile(clear=True, skip_connectivity=True)
+
+    def test_pre_oob(self):
+        f = self.network.connectivity.all_to_all.connect_cells
+
+        def pre_oob_connect(pre_set, post_set, src_locs, dest_locs, tag=None):
+            f(pre_set, post_set, src_locs + [100, 0, 0], dest_locs + [100, 0, 0])
+
+        self.network.connectivity.all_to_all.connect_cells = pre_oob_connect
+        self.network.compile(append=True, skip_placement=True)

--- a/test/test_cs.py
+++ b/test/test_cs.py
@@ -1,5 +1,6 @@
 from bsb.unittest import FixedPosConfigFixture, RandomStorageFixture, NumpyTestCase
 from bsb.core import Scaffold
+from bsb_hdf5.connectivity_set import LocationOutOfBoundsError
 import unittest
 
 
@@ -30,4 +31,5 @@ class TestConnectivitySet(
             f(pre_set, post_set, src_locs + [100, 0, 0], dest_locs + [100, 0, 0])
 
         self.network.connectivity.all_to_all.connect_cells = pre_oob_connect
-        self.network.compile(append=True, skip_placement=True)
+        with self.assertRaises(LocationOutOfBoundsError):
+            self.network.compile(append=True, skip_placement=True)


### PR DESCRIPTION
`load_block_connections` would error out if either the local or global chunk was empty. That's fixed and now empty data is returned instead. On top of that, while writing data with `connect`, the cell ids are checked for out of bounds locations.