### PR TITLE
Fix/morpho loaders

### DIFF
--- a/bsb_hdf5/morphology_repository.py
+++ b/bsb_hdf5/morphology_repository.py
@@ -81,6 +81,12 @@ class MorphologyRepository(Resource, IMorphologyRepository):
         return json.loads(handle["morphology_meta"][()], object_hook=meta_object_hook)
 
     @handles_handles("a")
+    def update_all_meta(self, meta, handle=HANDLED):
+        all_meta = self.get_all_meta(handle=handle)
+        all_meta.update(meta)
+        self.set_all_meta(all_meta, handle=handle)
+
+    @handles_handles("a")
     def set_all_meta(self, all_meta, handle=HANDLED):
         if "morphology_meta" in handle:
             del handle["morphology_meta"]

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -158,7 +158,7 @@ class PlacementSet(
         Preload the cell morphologies.
 
         :param handle: hdf5 file handler
-        :type handle: hdf5.File
+        :type handle: :class:`h5py.File`
         :param allow_empty: If False (default), will raise an error in absence of morphologies,
         :type allow_empty: bool
         :returns: MorphologySet object containing the loader of all morphologies
@@ -262,7 +262,7 @@ class PlacementSet(
         :param count: Amount of entities to place. Excludes the use of any positional,
           rotational or morphological data.
         :type count: int
-        :param handle: h5py file handler
+        :param handle: hdf5 file handler
         :type handle: :class:`h5py.Group`
         """
         if not isinstance(chunk, Chunk):

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -211,10 +211,15 @@ class PlacementSet(
             except KeyError:
                 continue
             for label in _map:
-                if label not in stor_mor and label in meta:
-                    stor_mor[label] = self._engine.morphologies.preload(
-                        name=label, meta=meta[label]
-                    )
+                if label not in stor_mor:
+                    if label in meta:
+                        stor_mor[label] = self._engine.morphologies.preload(
+                            name=label, meta=meta[label]
+                        )
+                    else:
+                        raise DatasetNotFoundError(
+                            f"No metadata found for stored morphology {label}"
+                        )
         return stor_mor
 
     @handles_handles("a")

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -212,8 +212,9 @@ class PlacementSet(
                 continue
             for label in _map:
                 if label not in stor_mor and label in meta:
-                    stor_mor[label] = self._engine.morphologies.preload(name=label,
-                                                                        meta=meta[label])
+                    stor_mor[label] = self._engine.morphologies.preload(
+                        name=label, meta=meta[label]
+                    )
         return stor_mor
 
     @handles_handles("a")
@@ -256,7 +257,7 @@ class PlacementSet(
         :type rotations: ~bsb.morphologies.RotationSet
         :param morphologies: Cell morphologies
         :type morphologies: ~bsb.morphologies.MorphologySet
-        :param additional: Additional data to attach to chunck
+        :param additional: Additional data to attach to chunk
         :type additional: dict
         :param count: Amount of entities to place. Excludes the use of any positional,
           rotational or morphological data.
@@ -306,7 +307,7 @@ class PlacementSet(
         :param count: Amount of entities to place. Excludes the use of any positional,
           rotational or morphological data.
         :type count: int
-        :param additional: Additional data to attach to chunck
+        :param additional: Additional data to attach to chunk
         :type additional: dict
         """
         self.append_data(chunk, count=count, additional=additional)


### PR DESCRIPTION
Fix `_get_morphology_loaders` to preload only once required morphologies and metadata.
Add documentation for `append_entities` and cast count to int before storing it as `numpy.int` is not supported by json.
Fix https://github.com/dbbs-lab/bsb-hdf5/issues/20
Fix https://github.com/dbbs-lab/bsb-hdf5/issues/21  
Add function to update morphology metadata.