### PR TITLE
fix: forward mpi comm to lock system

### DIFF
--- a/bsb_hdf5/__init__.py
+++ b/bsb_hdf5/__init__.py
@@ -92,7 +92,7 @@ class NoopLock:
 class HDF5Engine(Engine):
     def __init__(self, root, comm):
         super().__init__(root, comm)
-        self._lock = MPILock.sync()
+        self._lock = MPILock.sync(comm._comm)
         self._readonly = False
 
     @property


### PR DESCRIPTION
Forward MPI comm to lock system. Necessary for  https://github.com/dbbs-lab/bsb-core/pull/896