### PR TITLE
feat: Add method to convert global ids to local ids for PlacementSet

### DIFF
--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -11,7 +11,10 @@ from bsb import (
     MorphologySet,
 )
 from bsb import PlacementSet as IPlacementSet
-from bsb import RotationSet, config
+from bsb import (
+    RotationSet,
+    config,
+)
 from bsb._encoding import EncodedLabels
 
 from .chunks import ChunkedCollection, ChunkedProperty, ChunkLoader

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -523,11 +523,10 @@ class PlacementSet(
                 - cumulative_chunk_lengths[filtered_chunk_id[i]]
                 + local_cumulative_lenghts[filtered_chunk_id[i]]
             )
-
         return (
             converted_ids
             if len(converted_ids) > 0
-            else np.full(np.sum(local_chunks_stats[:, 1]), False)
+            else np.full(np.sum(local_chunks_stats), False)
         )
 
 

--- a/bsb_hdf5/placement_set.py
+++ b/bsb_hdf5/placement_set.py
@@ -495,7 +495,7 @@ class PlacementSet(
         cumulative_chunk_lengths = np.cumsum(ordered_stats[:, 1])
 
         # Get list of Chunk id for every number in ids -> chunk_id_of_glob
-        chunk_id_of_glob = np.searchsorted(cumulative_chunk_lengths, ids)
+        chunk_id_of_glob = np.searchsorted(cumulative_chunk_lengths - 1, ids)
 
         # Now i will need to select only local chunks
         local_chunk_filter = np.isin(ordered_stats[:, 0], chunks)

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -17,12 +17,22 @@ class TestPlacementSet(_TestPlacementSet, unittest.TestCase, engine_name="hdf5")
         ps = self.network.get_placement_set("test_cell")
         # Def a list of ids
         glob_ids = [0, 3, 44, 77]
-        # Now we select to work on 2nd and 4rd chunk only
+        # Now we select to work on 2nd and 4th chunk only
         ps.set_chunk_filter([(1, 0, 0), (1, 0, 1)])
         local_ids = ps.convert_to_local(glob_ids)
         self.assertAll(
             local_ids == np.array([19, 27]),
             " [0,3] should have been discarded, [44,77] should have been converted to [19,27]",
+        )
+        # test when the selected chunks do not have any of the cell ids
+        ps.set_chunk_filter([(0, 0, 1)])
+        local_ids = ps.convert_to_local(glob_ids)
+        # Get pop size of 3rd chunk
+        pop_size = ps.get_chunk_stats()[str(self.chunks[1].id)]
+        res_array = np.full(pop_size, False)
+        self.assertAll(
+            local_ids == res_array,
+            "If selected chunk has no one of the ids it should return an array of pop_size size filled with False value",
         )
 
 

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -17,7 +17,7 @@ class TestPlacementSet(_TestPlacementSet, unittest.TestCase, engine_name="hdf5")
         ps = self.network.get_placement_set("test_cell")
         # Def a list of ids
         glob_ids = [0, 3, 44, 77]
-        # Now we select to work on 2nd and 4th chunk only
+        # Now we select to work on 2nd and 4th chunk only ( ordering is made on chunk id)
         ps.set_chunk_filter([(1, 0, 0), (1, 0, 1)])
         local_ids = ps.convert_to_local(glob_ids)
         self.assertAll(
@@ -32,7 +32,7 @@ class TestPlacementSet(_TestPlacementSet, unittest.TestCase, engine_name="hdf5")
         res_array = np.full(pop_size, False)
         self.assertAll(
             local_ids == res_array,
-            "If selected chunk has no one of the ids it should return an array of pop_size size filled with False value",
+            "If selected chunk has no one of the ids it should return an array of pop_size size filled with False values",
         )
 
 

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 from bsb_test.engines import TestConnectivitySet as _TestConnectivitySet
 from bsb_test.engines import TestMorphologyRepository as _TestMorphologyRepository
 from bsb_test.engines import TestPlacementSet as _TestPlacementSet
@@ -11,7 +12,18 @@ class TestStorage(_TestStorage, unittest.TestCase, engine_name="hdf5"):
 
 
 class TestPlacementSet(_TestPlacementSet, unittest.TestCase, engine_name="hdf5"):
-    pass
+    def test_convert_to_local(self):
+        self.network.compile()
+        ps = self.network.get_placement_set("test_cell")
+        # Def a list of ids
+        glob_ids = [0, 3, 44, 77]
+        # Now we select to work on 2nd and 4rd chunk only
+        ps.set_chunk_filter([(1, 0, 0), (1, 0, 1)])
+        local_ids = ps.convert_to_local(glob_ids)
+        self.assertAll(
+            local_ids == np.array([19, 27]),
+            " [0,3] should have been discarded, [44,77] should have been converted to [19,27]",
+        )
 
 
 class TestMorphologyRepository(

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -16,13 +16,13 @@ class TestPlacementSet(_TestPlacementSet, unittest.TestCase, engine_name="hdf5")
         self.network.compile()
         ps = self.network.get_placement_set("test_cell")
         # Def a list of ids
-        glob_ids = [0, 3, 44, 77]
+        glob_ids = [0, 3, 44, 77, 25]
         # Now we select to work on 2nd and 4th chunk only ( ordering is made on chunk id)
         ps.set_chunk_filter([(1, 0, 0), (1, 0, 1)])
         local_ids = ps.convert_to_local(glob_ids)
         self.assertAll(
-            local_ids == np.array([19, 27]),
-            " [0,3] should have been discarded, [44,77] should have been converted to [19,27]",
+            local_ids == np.array([19, 27, 0]),
+            " [0,3] should have been discarded, [44,77,25] should have been converted to [19,27,0]",
         )
         # test when the selected chunks do not have any of the cell ids
         ps.set_chunk_filter([(0, 0, 1)])


### PR DESCRIPTION
Since the need to deal with global ids for targetting classes i add a method to convert ids called: convert_to_local.


it is linked to the PR in bsb-core: https://github.com/dbbs-lab/bsb-core/pull/898

- [X] Add test